### PR TITLE
CUDA separable compilation

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -56,6 +56,11 @@ add_executable(bench-k-selection "bench-k-selection.cu")
 
 configure_thrustshift_app_target(bench-k-selection)
 
+#######################################################
+# FOR RELOCATABLE DEVICE CODE AND DYNAMIC PARALELLISM #
+#######################################################
+set_target_properties(bench-k-selection PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+
 target_link_libraries(
   bench-k-selection
   PRIVATE Boost::program_options thrustshift
@@ -68,6 +73,11 @@ target_link_libraries(
 add_executable(bench-bin-values256 "bench-bin-values256.cu")
 
 configure_thrustshift_app_target(bench-bin-values256)
+
+#######################################################
+# FOR RELOCATABLE DEVICE CODE AND DYNAMIC PARALELLISM #
+#######################################################
+set_target_properties(bench-bin-values256 PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 target_link_libraries(
   bench-bin-values256

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,11 @@ if(CMAKE_CUDA_COMPILER_ID MATCHES "NVIDIA")
                              $<$<COMPILE_LANGUAGE:CUDA>:BOOST_PP_VARIADICS=1>)
 endif()
 
+#######################################################
+# FOR RELOCATABLE DEVICE CODE AND DYNAMIC PARALELLISM #
+#######################################################
+set_target_properties(test-thrustshift PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+
 target_link_libraries(
   test-thrustshift
   PRIVATE Boost::unit_test_framework Boost::filesystem thrustshift Eigen3::Eigen matrixmarket::matrixmarket


### PR DESCRIPTION
Added CUDA separable compilation flag to apps and test so they compile without the need to specify this flag on the command line (or in a spack package).