### PR TITLE
Fix calls to cuda-api-wrappers@0.4.4

### DIFF
--- a/include/thrustshift/histogram.h
+++ b/include/thrustshift/histogram.h
@@ -37,7 +37,7 @@ void bin_values_into_histogram(cuda::stream_t& stream,
 		                                                         lower_level,
 		                                                         upper_level,
 		                                                         num_samples,
-		                                                         stream.id()));
+		                                                         stream.handle()));
 	};
 	exec();
 	auto tmp =

--- a/include/thrustshift/k-selection.h
+++ b/include/thrustshift/k-selection.h
@@ -2198,10 +2198,11 @@ void select_k_largest_values_abs(cuda::stream_t& stream,
 	k_s[0] = k;
 
 	auto c = cuda::make_launch_config(grid_dim, block_dim);
+	c.block_cooperation = true;
+
 	const int N = values.size();
 
 	cuda::enqueue_launch(
-	    cuda::thread_blocks_may_cooperate,
 	    kernel::
 	        k_select_radix<T, unsigned, block_dim, grid_dim, num_sh_histograms>,
 	    stream,
@@ -2261,10 +2262,10 @@ void select_k_largest_values_abs2(cuda::stream_t& stream,
 	k_s[0] = k;
 
 	auto c = cuda::make_launch_config(grid_dim, block_dim);
+	c.block_cooperation = true;
 	const int N = values.size();
 
-	cuda::enqueue_launch(cuda::thread_blocks_may_cooperate,
-	                     kernel::k_select_radix2<T,
+	cuda::enqueue_launch(kernel::k_select_radix2<T,
 	                                             unsigned,
 	                                             block_dim,
 	                                             grid_dim,

--- a/include/thrustshift/reduction.h
+++ b/include/thrustshift/reduction.h
@@ -33,7 +33,7 @@ void reduce(cuda::stream_t& stream,
 		                              gsl_lite::narrow<int>(values.size()),
 		                              reduction_functor,
 		                              initial_value,
-		                              stream.id()));
+		                              stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -71,7 +71,7 @@ void segmented_reduce(cuda::stream_t& stream,
 		    segment_ptrs.data() + 1,
 		    reduction_functor,
 		    initial_value,
-		    stream.id()));
+		    stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -108,7 +108,7 @@ void segmented_reduce(cuda::stream_t& stream,
 		                                       segment_ptrs + 1,
 		                                       reduction_functor,
 		                                       initial_value,
-		                                       stream.id()));
+		                                       stream.handle()));
 	};
 	exec();
 	auto tmp =

--- a/include/thrustshift/scan.h
+++ b/include/thrustshift/scan.h
@@ -36,7 +36,7 @@ void inclusive_scan(cuda::stream_t& stream,
 		                                                    values_out.data(),
 		                                                    scan_op,
 		                                                    N,
-		                                                    stream.id()));
+		                                                    stream.handle()));
 	};
 	exec();
 	auto tmp =

--- a/include/thrustshift/select-if.h
+++ b/include/thrustshift/select-if.h
@@ -161,7 +161,7 @@ void select_if(cuda::stream_t& stream,
 		                                           num_selected_ptr,
 		                                           N,
 		                                           select_op,
-		                                           stream.id()));
+		                                           stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -194,7 +194,7 @@ void select_if(cuda::stream_t& stream,
 		                                           num_selected_ptr,
 		                                           N,
 		                                           select_op,
-		                                           stream.id()));
+		                                           stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -245,7 +245,7 @@ void select_if_with_index(cuda::stream_t& stream,
 		                                           num_selected_ptr,
 		                                           N,
 		                                           select_op,
-		                                           stream.id()));
+		                                           stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -290,7 +290,7 @@ void select_if_with_index(cuda::stream_t& stream,
 		                                           num_selected_ptr,
 		                                           N,
 		                                           select_op,
-		                                           stream.id()));
+		                                           stream.handle()));
 	};
 	exec();
 	auto tmp =

--- a/include/thrustshift/sort.h
+++ b/include/thrustshift/sort.h
@@ -190,7 +190,7 @@ void sort_batched_descending(cuda::stream_t& stream,
 		    tit + 1,
 		    0, // default value by CUB
 		    sizeof(KeyT) * 8, // default value by CUB
-		    stream.id()));
+		    stream.handle()));
 	};
 	exec();
 	auto tmp =
@@ -264,7 +264,7 @@ void sort_batched_abs(cuda::stream_t& stream,
 		    tit + 1,
 		    0, // first key bit for comparison
 		    sizeof(KeyT) * 8 - 1, // highest bit is used to save sign
-		    stream.id()));
+		    stream.handle()));
 	};
 	exec();
 	auto tmp =

--- a/include/thrustshift/wrap-subgroups.h
+++ b/include/thrustshift/wrap-subgroups.h
@@ -127,7 +127,7 @@ void wrap_subgroups(cuda::stream_t& stream,
 		                                           group_ptrs_size,
 		                                           group_ptrs.size(),
 		                                           f,
-		                                           stream.id()));
+		                                           stream.handle()));
 	};
 	// set temporary memory size only
 	enqueue_select_if();


### PR DESCRIPTION
cuda-api-wrappers changed part of its public API between 0.4.3 and 0.4.4:
* use `stream.handle()` instead of old `stream.id()` (See eyalroz/cuda-api-wrappers#280)
* incorporate thread block coop switch into launch config instead of it being an argument to `enqueue_launch` (See eyalroz/cuda-api-wrappers#258)