### PR TITLE
Fix compiler errors and warnings

### DIFF
--- a/app/bench-bin-values256.cu
+++ b/app/bench-bin-values256.cu
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include <array>
 #include <chrono>
 #include <iostream>
@@ -170,7 +172,8 @@ int main(int argc, const char* argv[]) {
 				    [prefix, bit_offset] __host__ __device__(const T& x) {
 					    using std::abs;
 					    const T abs_x = abs(x);
-					    const I k = *reinterpret_cast<I*>((void*) (&abs_x));
+					    I k;
+					    std::memcpy(&k, &abs_x, sizeof(I));
 					    return k;
 				    });
 				async::bin_values_into_histogram(stream,

--- a/include/thrustshift/COO.h
+++ b/include/thrustshift/COO.h
@@ -697,17 +697,17 @@ template <typename DataType,
           class UnaryOperatorB0,
           class UnaryOperatorB1,
           class MemoryResource>
-std::tuple<thrustshift::COO<DataType, IndexType>,
-           decltype(thrustshift::make_not_a_vector<DataType>(1,
-                                                             MemoryResource{}))>
-transform2(thrustshift::COO_view<const DataType, const IndexType> a,
-           thrustshift::COO_view<const DataType, const IndexType> b,
-           BinaryOperator&& op,
-           UnaryOperatorA0&& op_a0,
-           UnaryOperatorA1&& op_a1,
-           UnaryOperatorB0&& op_b0,
-           UnaryOperatorB1&& op_b1,
-           MemoryResource& memory_resource) {
+auto transform2(thrustshift::COO_view<const DataType, const IndexType> a,
+                thrustshift::COO_view<const DataType, const IndexType> b,
+                BinaryOperator&& op,
+                UnaryOperatorA0&& op_a0,
+                UnaryOperatorA1&& op_a1,
+                UnaryOperatorB0&& op_b0,
+                UnaryOperatorB1&& op_b1,
+                MemoryResource& memory_resource)
+    -> std::tuple<thrustshift::COO<DataType, IndexType>,
+                  decltype(thrustshift::make_not_a_vector<
+                           DataType>(1, memory_resource))> {
 
 	const auto nnz_a = a.values().size();
 	const auto nnz_b = b.values().size();
@@ -776,10 +776,8 @@ transform2(thrustshift::COO_view<const DataType, const IndexType> a,
 		    thrust::make_tuple(values0.begin(), values1.begin()));
 
 		std::pmr::polymorphic_allocator<KeyT> alloc(&memory_resource);
-		thrust::sort_by_key(thrust::cuda::par(alloc),
-		                    keys_begin,
-		                    keys_end,
-		                    zip_value_it.begin());
+		thrust::sort_by_key(
+		    thrust::cuda::par(alloc), keys_begin, keys_end, zip_value_it);
 
 		const std::size_t nnz_result =
 		    thrust::inner_product(thrust::cuda::par(alloc),
@@ -822,7 +820,7 @@ transform2(thrustshift::COO_view<const DataType, const IndexType> a,
 		thrust::reduce_by_key(thrust::cuda::par(alloc),
 		                      keys_begin,
 		                      keys_end,
-		                      zip_value_it.begin(),
+		                      zip_value_it,
 		                      keys_result_begin,
 		                      zip_result_it,
 		                      thrust::equal_to<KeyT>(),
@@ -908,12 +906,12 @@ COO<DataType, IndexType> make_pattern_symmetric(
 }
 
 template <typename DataType, typename IndexType, class MemoryResource>
-std::tuple<thrustshift::COO<DataType, IndexType>,
-           decltype(thrustshift::make_not_a_vector<DataType>(1,
-                                                             MemoryResource{}))>
-symmetrize_abs_and_make_pattern_symmetric(
+auto symmetrize_abs_and_make_pattern_symmetric(
     COO_view<const DataType, const IndexType> mtx,
-    MemoryResource& memory_resource) {
+    MemoryResource& memory_resource)
+    -> std::tuple<thrustshift::COO<DataType, IndexType>,
+                  decltype(thrustshift::make_not_a_vector<
+                           DataType>(1, memory_resource))> {
 
 	gsl_Expects(!mtx.values().empty());
 


### PR DESCRIPTION
`COO.h` has major bugs, i.e. wasn't compilable.

Other than that there were warnings about type punning using `*reinterpret_cast<T *>(&x)` which I solved using `memcpy` which is the correct way of doing type punning in C++.  I checked on Compiler Explorer that the generated code is the same as before, even at PTX level.